### PR TITLE
Reuse the ctx with ChaCha20Poly1305

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/aead.py
+++ b/src/cryptography/hazmat/backends/openssl/aead.py
@@ -26,11 +26,15 @@ def _aead_cipher_name(cipher):
         return "aes-{}-gcm".format(len(cipher._key) * 8).encode("ascii")
 
 
-def _aead_setup(backend, cipher_name, key, nonce, tag, tag_len, operation):
-    evp_cipher = backend._lib.EVP_get_cipherbyname(cipher_name)
-    backend.openssl_assert(evp_cipher != backend._ffi.NULL)
+def _create_ctx(backend):
     ctx = backend._lib.EVP_CIPHER_CTX_new()
     ctx = backend._ffi.gc(ctx, backend._lib.EVP_CIPHER_CTX_free)
+    return ctx
+
+
+def _set_cipher(backend, ctx, cipher_name, operation):
+    evp_cipher = backend._lib.EVP_get_cipherbyname(cipher_name)
+    backend.openssl_assert(evp_cipher != backend._ffi.NULL)
     res = backend._lib.EVP_CipherInit_ex(
         ctx,
         evp_cipher,
@@ -40,37 +44,87 @@ def _aead_setup(backend, cipher_name, key, nonce, tag, tag_len, operation):
         int(operation == _ENCRYPT),
     )
     backend.openssl_assert(res != 0)
-    res = backend._lib.EVP_CIPHER_CTX_set_key_length(ctx, len(key))
-    backend.openssl_assert(res != 0)
-    res = backend._lib.EVP_CIPHER_CTX_ctrl(
-        ctx,
-        backend._lib.EVP_CTRL_AEAD_SET_IVLEN,
-        len(nonce),
-        backend._ffi.NULL,
-    )
-    backend.openssl_assert(res != 0)
-    if operation == _DECRYPT:
-        res = backend._lib.EVP_CIPHER_CTX_ctrl(
-            ctx, backend._lib.EVP_CTRL_AEAD_SET_TAG, len(tag), tag
-        )
-        backend.openssl_assert(res != 0)
-    elif cipher_name.endswith(b"-ccm"):
-        res = backend._lib.EVP_CIPHER_CTX_ctrl(
-            ctx, backend._lib.EVP_CTRL_AEAD_SET_TAG, tag_len, backend._ffi.NULL
-        )
-        backend.openssl_assert(res != 0)
 
-    nonce_ptr = backend._ffi.from_buffer(nonce)
+
+def _set_key_len(backend, ctx, key_len):
+    res = backend._lib.EVP_CIPHER_CTX_set_key_length(ctx, key_len)
+    backend.openssl_assert(res != 0)
+
+
+def _set_key(backend, ctx, key, operation):
     key_ptr = backend._ffi.from_buffer(key)
     res = backend._lib.EVP_CipherInit_ex(
         ctx,
         backend._ffi.NULL,
         backend._ffi.NULL,
         key_ptr,
+        backend._ffi.NULL,
+        int(operation == _ENCRYPT),
+    )
+    backend.openssl_assert(res != 0)
+
+
+def _set_decrypt_tag(backend, ctx, tag):
+    res = backend._lib.EVP_CIPHER_CTX_ctrl(
+        ctx, backend._lib.EVP_CTRL_AEAD_SET_TAG, len(tag), tag
+    )
+    backend.openssl_assert(res != 0)
+
+
+def _set_ccm_tag_len(backend, ctx, tag_len):
+    res = backend._lib.EVP_CIPHER_CTX_ctrl(
+        ctx, backend._lib.EVP_CTRL_AEAD_SET_TAG, tag_len, backend._ffi.NULL
+    )
+    backend.openssl_assert(res != 0)
+
+
+def _set_nonce_len(backend, ctx, nonce_len):
+    res = backend._lib.EVP_CIPHER_CTX_ctrl(
+        ctx,
+        backend._lib.EVP_CTRL_AEAD_SET_IVLEN,
+        nonce_len,
+        backend._ffi.NULL,
+    )
+    backend.openssl_assert(res != 0)
+
+
+def _set_nonce(backend, ctx, nonce, operation):
+    nonce_ptr = backend._ffi.from_buffer(nonce)
+    res = backend._lib.EVP_CipherInit_ex(
+        ctx,
+        backend._ffi.NULL,
+        backend._ffi.NULL,
+        backend._ffi.NULL,
         nonce_ptr,
         int(operation == _ENCRYPT),
     )
     backend.openssl_assert(res != 0)
+
+
+def _aead_setup_with_variable_nonce_len(
+    backend, cipher_name, key, nonce, tag, tag_len, operation
+):
+    ctx = _create_ctx(backend)
+    _set_cipher(backend, ctx, cipher_name, operation)
+    _set_key_len(backend, ctx, len(key))
+    _set_nonce_len(backend, ctx, len(nonce))
+    if operation == _DECRYPT:
+        _set_decrypt_tag(backend, ctx, tag)
+    elif cipher_name.endswith(b"-ccm"):
+        _set_ccm_tag_len(backend, ctx, tag_len)
+    _set_key(backend, ctx, key, operation)
+    _set_nonce(backend, ctx, nonce, operation)
+    return ctx
+
+
+def _aead_setup_with_fixed_nonce_len(
+    backend, cipher_name, key, nonce_len, operation
+):
+    ctx = _create_ctx(backend)
+    _set_cipher(backend, ctx, cipher_name, operation)
+    _set_key_len(backend, ctx, len(key))
+    _set_key(backend, ctx, key, operation)
+    _set_nonce_len(backend, ctx, nonce_len)
     return ctx
 
 
@@ -99,12 +153,32 @@ def _process_data(backend, ctx, data):
 
 
 def _encrypt(backend, cipher, nonce, data, associated_data, tag_length):
+    ctx = _aead_setup_with_variable_nonce_len(
+        backend,
+        _aead_cipher_name(cipher),
+        cipher._key,
+        nonce,
+        None,
+        tag_length,
+        _ENCRYPT,
+    )
+    return _encrypt_data(
+        backend, ctx, cipher, data, associated_data, tag_length
+    )
+
+
+def _encrypt_with_fixed_nonce_len(
+    backend, ctx, cipher, nonce, data, associated_data, tag_length
+):
+    _set_nonce(backend, ctx, nonce, _ENCRYPT)
+    return _encrypt_data(
+        backend, ctx, cipher, data, associated_data, tag_length
+    )
+
+
+def _encrypt_data(backend, ctx, cipher, data, associated_data, tag_length):
     from cryptography.hazmat.primitives.ciphers.aead import AESCCM
 
-    cipher_name = _aead_cipher_name(cipher)
-    ctx = _aead_setup(
-        backend, cipher_name, cipher._key, nonce, None, tag_length, _ENCRYPT
-    )
     # CCM requires us to pass the length of the data before processing anything
     # However calling this with any other AEAD results in an error
     if isinstance(cipher, AESCCM):
@@ -126,40 +200,68 @@ def _encrypt(backend, cipher, nonce, data, associated_data, tag_length):
     return processed_data + tag
 
 
+def _tag_from_data(data, tag_length):
+    if len(data) < tag_length:
+        raise InvalidTag
+    return data[-tag_length:]
+
+
 def _decrypt(backend, cipher, nonce, data, associated_data, tag_length):
     from cryptography.hazmat.primitives.ciphers.aead import AESCCM
 
-    if len(data) < tag_length:
-        raise InvalidTag
-    tag = data[-tag_length:]
+    tag = _tag_from_data(data, tag_length)
     data = data[:-tag_length]
-    cipher_name = _aead_cipher_name(cipher)
-    ctx = _aead_setup(
-        backend, cipher_name, cipher._key, nonce, tag, tag_length, _DECRYPT
+
+    ctx = _aead_setup_with_variable_nonce_len(
+        backend,
+        _aead_cipher_name(cipher),
+        cipher._key,
+        nonce,
+        tag,
+        tag_length,
+        _DECRYPT,
     )
+
+    if isinstance(cipher, AESCCM):
+        return _decrypt_data_aesccm(backend, ctx, data, associated_data)
+
+    return _decrypt_data(backend, ctx, data, associated_data)
+
+
+def _decrypt_with_fixed_nonce_len(
+    backend, ctx, nonce, data, associated_data, tag_length
+):
+    tag = _tag_from_data(data, tag_length)
+    data = data[:-tag_length]
+    _set_nonce(backend, ctx, nonce, _DECRYPT)
+    _set_decrypt_tag(backend, ctx, tag)
+    return _decrypt_data(backend, ctx, data, associated_data)
+
+
+def _decrypt_data_aesccm(backend, ctx, data, associated_data):
     # CCM requires us to pass the length of the data before processing anything
     # However calling this with any other AEAD results in an error
-    if isinstance(cipher, AESCCM):
-        _set_length(backend, ctx, len(data))
+    _set_length(backend, ctx, len(data))
 
     _process_aad(backend, ctx, associated_data)
     # CCM has a different error path if the tag doesn't match. Errors are
     # raised in Update and Final is irrelevant.
-    if isinstance(cipher, AESCCM):
-        outlen = backend._ffi.new("int *")
-        buf = backend._ffi.new("unsigned char[]", len(data))
-        res = backend._lib.EVP_CipherUpdate(ctx, buf, outlen, data, len(data))
-        if res != 1:
-            backend._consume_errors()
-            raise InvalidTag
+    outlen = backend._ffi.new("int *")
+    buf = backend._ffi.new("unsigned char[]", len(data))
+    res = backend._lib.EVP_CipherUpdate(ctx, buf, outlen, data, len(data))
+    if res != 1:
+        backend._consume_errors()
+        raise InvalidTag
+    return backend._ffi.buffer(buf, outlen[0])[:]
 
-        processed_data = backend._ffi.buffer(buf, outlen[0])[:]
-    else:
-        processed_data = _process_data(backend, ctx, data)
-        outlen = backend._ffi.new("int *")
-        res = backend._lib.EVP_CipherFinal_ex(ctx, backend._ffi.NULL, outlen)
-        if res == 0:
-            backend._consume_errors()
-            raise InvalidTag
+
+def _decrypt_data(backend, ctx, data, associated_data):
+    _process_aad(backend, ctx, associated_data)
+    processed_data = _process_data(backend, ctx, data)
+    outlen = backend._ffi.new("int *")
+    res = backend._lib.EVP_CipherFinal_ex(ctx, backend._ffi.NULL, outlen)
+    if res == 0:
+        backend._consume_errors()
+        raise InvalidTag
 
     return processed_data


### PR DESCRIPTION
- When profiling camera snapshots from `HAP-python`, which splits
  each frame into 1024 encrypted blocks, I noticed ~30% of the time
  was spent in `_aead_setup`. ChaCha20Poly1305 can reuse the ctx
  so we only have to set the `nonce` which 1/3 the time of `_aead_setup`.
  The overall speed up is roughly 20%
  
Before:
<img width="582" alt="Screen Shot 2021-07-31 at 12 38 24 PM" src="https://user-images.githubusercontent.com/663432/127748111-9a20446b-2fc8-499a-8df0-53e719eb8fb2.png">


After:
<img width="592" alt="Screen Shot 2021-07-31 at 12 38 19 PM" src="https://user-images.githubusercontent.com/663432/127748105-6729931a-4e44-45f5-8c84-47935edb20ac.png">

